### PR TITLE
pyparsing 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.7" %}
+{% set version = "3.0.4" %}
 
 package:
   name: pyparsing
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyparsing/pyparsing-{{ version }}.tar.gz
-  sha256: c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
+  sha256: e0df773d7fa2240322daae7805626dfc5f2d5effb34e1a7be2702c99cfb9f6b1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -17,20 +18,26 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:
     - pyparsing
+    - pyparsing.diagram
+  requires:
+    - jinja2
+    - pip
+    - python <3.10
   commands:
     - pip check
-  requires:
-    - pip
 
 about:
-  home: http://pyparsing.wikispaces.com/
+  home: https://github.com/pyparsing/pyparsing/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Create and execute simple grammars
   description: |
@@ -38,8 +45,8 @@ about:
     simple grammars, vs. the traditional lex/yacc approach, or the use of
     regular expressions. The pyparsing module provides a library of classes
     that client code uses to construct the grammar directly in Python code.
-  doc_url: http://pyparsing.wikispaces.com/Documentation
-  dev_url: https://svn.code.sf.net/p/pyparsing/code/
+  doc_url: https://github.com/pyparsing/pyparsing/blob/master/docs/HowToUsePyparsing.rst
+  dev_url: https://github.com/pyparsing/pyparsing/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,7 @@ requirements:
 test:
   imports:
     - pyparsing
-    - pyparsing.diagram
   requires:
-    - jinja2
     - pip
     - python <3.10
   commands:


### PR DESCRIPTION
Update pyparsing to 3.0.4

Category:  anaconda | subcategory:  dependency | pkg_type:  python
Popularity:  15857614 downloads -  pyparsing  3.0.4  Create and execute simple grammars
Version change: bump version number from 2.4.7 to 3.0.4 (Major version bump!)
  license: MIT
Release date:  Oct 30, 2021
Bug Tracker: new open issues https://github.com/pyparsing/pyparsing/issues
Github changelog: https://github.com/pyparsing/pyparsing/blob/master/CHANGES
Upstream setup file: https://github.com/pyparsing/pyparsing/blob/pyparsing_3.0.4/setup.py  

The package pyparsing is mentioned inside the packages:
docker-py | matplotlib | poetry | pydot | pydotplus | pyparsing | snuggs |

Actions:
1. Add missing packages setuptools, wheel
2. Add skip py<36
3. Update test/imports
4. Add license_family
5. Update home, dev, doc urls

Result:
- all-succeeded
