### PR TITLE
Update `pyparsing` to version  `3.0.7`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.4" %}
+{% set version = "3.0.7" %}
 
 package:
   name: pyparsing
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyparsing/pyparsing-{{ version }}.tar.gz
-  sha256: e0df773d7fa2240322daae7805626dfc5f2d5effb34e1a7be2702c99cfb9f6b1
+  sha256: 18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 build:
   number: 0
   skip: True  # [py<36]
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -21,14 +20,13 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
     - pyparsing
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 
@@ -43,7 +41,8 @@ about:
     simple grammars, vs. the traditional lex/yacc approach, or the use of
     regular expressions. The pyparsing module provides a library of classes
     that client code uses to construct the grammar directly in Python code.
-  doc_url: https://github.com/pyparsing/pyparsing/blob/master/docs/HowToUsePyparsing.rst
+  doc_url: https://pyparsing-docs.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/pyparsing/pyparsing/blob/master/docs/HowToUsePyparsing.rst
   dev_url: https://github.com/pyparsing/pyparsing/
 
 extra:


### PR DESCRIPTION
`pyparsing` version `3.0.7`
1. - [x] Check the upstream

  https://github.com/pyparsing/pyparsing/tree/pyparsing_3.0.7

2. - [x] Check the pinnings

  `python` is supported for versions `3.6` to `3.10`
  https://github.com/pyparsing/pyparsing/blob/pyparsing_3.0.7/tox.ini#L4

3. - [x] Check the changelogs

  https://github.com/pyparsing/pyparsing/blob/pyparsing_3.0.7/CHANGES

  The only changes mentioned were bug fixes and new features.

4. - [x] Additional research

    https://github.com/conda-forge/pyparsing-feedstock/issues

    There is a known issue on `python 3.6.0` where the `version_info` object has no attribute `__version__` (issue #36)

    since we no longer support `python 3.6` or earlier we can conclude that the `issue 36` will not affect our builds. 

5. - [x] Verify the `dev_url`
    https://github.com/pyparsing/pyparsing/

6. - [x] Verify the `doc_url`

    the doc_url had to be modified to reflect the latest changes mentioned on the readme file:

    https://pyparsing-docs.readthedocs.io/en/latest/
    
7. - [x] License is `spdx` compliant

https://github.com/pyparsing/pyparsing/blob/pyparsing_3.0.7/LICENSE

https://spdx.org/licenses/MIT.html

8. - [x] License family is present
9. - [x] Verify that the build number is correct
10. - [x] Verify if the package needs `setuptools`
11. - [x] Verify if the package needs `wheel`
12. - [x] `pip` in the test section
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture` specific or `noarch`
 
Results:
- 
 
Based on the research findings and the results we can conclude
that it is safe to update `pyparsing` to version `3.0.7`
