### PR TITLE
Update `pyparsing` to version `3.0.9`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - flit-core >=3.2
+    - flit-core >=3.2,<4
     # flit-core requires tomli
     - tomli
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - flit >=3.2,<4
+    # - flit >=3.2,<4
+    - flit-core >=3.2,<4
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - flit-core >=3.2,<4
-    # flit-core requires tomli
-    - tomli
+    - flit >=3.2,<4
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.4" %}
+{% set version = "3.0.9" %}
 
 package:
   name: pyparsing
@@ -6,12 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyparsing/pyparsing-{{ version }}.tar.gz
-  sha256: e0df773d7fa2240322daae7805626dfc5f2d5effb34e1a7be2702c99cfb9f6b1
+  sha256: 2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb
 
 build:
   number: 0
-  skip: True  # [py<36]
-  noarch: python
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -20,15 +19,17 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - flit-core >=3.2
+    # flit-core requires tomli
+    - tomli
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
     - pyparsing
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - pip
     - setuptools
     - wheel
-    # - flit >=3.2,<4
     - flit-core >=3.2,<4
   run:
     - python


### PR DESCRIPTION
`pyparsing` version `3.0.9`
1. - [x] Check the upstream
    https://github.com/pyparsing/pyparsing/tree/pyparsing_3.0.9
2. - [x] Check the pinnings

  `python version >=3.6.8`
  https://github.com/pyparsing/pyparsing/blob/pyparsing_3.0.9/pyproject.toml#L11

  `flit-core >=3.2`
  https://github.com/pyparsing/pyparsing/blob/pyparsing_3.0.9/pyproject.toml#L2


3. - [x] Check the changelogs
    https://github.com/pyparsing/pyparsing/blob/pyparsing_3.0.9/CHANGES

    Version 3.0.9 -
---------------
- Added Unicode set `BasicMultilingualPlane` (may also be referenced
  as `BMP`) representing the Basic Multilingual Plane (Unicode
  characters up to code point 65535). Can be used to parse
  most language characters, but omits emojis, wingdings, etc.
  Raised in discussion with Dave Tapley (issue #392).
  https://github.com/pyparsing/pyparsing/issues/392

- To address mypy confusion of `pyparsing.Optional` and `typing.Optional`
  resulting in `error: "_SpecialForm" not callable` message
  reported in issue #365, fixed the import in exceptions.py. Nice
  sleuthing by Iwan Aucamp and Dominic Davis-Foster, thank you!
  (Removed definitions of `OptionalType`, `DictType`, and `IterableType`
  and replaced them with `typing.Optional`, `typing.Dict`, and
  `typing.Iterable` throughout.)
  https://github.com/pyparsing/pyparsing/pull/365

- Fixed typo in jinja2 template for railroad diagrams, thanks for the
  catch Nioub (issue #388).
  https://github.com/pyparsing/pyparsing/issues/388

- Removed use of deprecated `pkg_resources` package in
  railroad diagramming code (issue #391).
  https://github.com/pyparsing/pyparsing/issues/391

- Updated bigquery_view_parser.py example to parse examples at
  https://cloud.google.com/bigquery/docs/reference/legacy-sql

  Version 3.0.8 -
---------------
- API CHANGE: modified pyproject.toml to require Python version
  3.6.8 or later for pyparsing 3.x. Earlier minor versions of 3.6
  fail in evaluating the `version_info` class (implemented using
  `typing.NamedTuple`). If you are using an earlier version of Python
  3.6, you will need to use pyparsing 2.4.7.

- Improved pyparsing import time by deferring regex pattern compiles.
  PR submitted by Anthony Sottile to fix issue #362, thanks!
  https://github.com/pyparsing/pyparsing/issues/362

- Updated build to use flit, PR by Michał Górny, added BUILDING.md
  doc and removed old Windows build scripts - nice cleanup work!

- More type-hinting added for all arithmetic and logical operator
  methods in `ParserElement`. PR from Kazantcev Andrey, thank you.

- Fixed `infix_notation`'s definitions of `lpar` and `rpar`, to accept
  parse expressions such that they do not get suppressed in the parsed
  results. PR submitted by Philippe Prados, nice work.

- Fixed bug in railroad diagramming with expressions containing `Combine`
  elements. Reported by Jeremy White, thanks!

- Added `show_groups` argument to `create_diagram` to highlight grouped
  elements with an unlabeled bounding box.

- Added `unicode_denormalizer.py` to the examples as a demonstration
  of how Python's interpreter will accept Unicode characters in
  identifiers, but normalizes them back to ASCII so that identifiers
  `print` and `𝕡𝓻ᵢ𝓃𝘁` and `𝖕𝒓𝗂𝑛ᵗ` are all equivalent.

- Removed imports of deprecated `sre_constants` module for catching
  exceptions when compiling regular expressions. PR submitted by
  Serhiy Storchaka, thank you.

Version 3.0.7 -
---------------
- Fixed bug #345, in which delimitedList changed expressions in place
  using `expr.streamline()`. Reported by Kim Gräsman, thanks!
  https://github.com/pyparsing/pyparsing/issues/345

- Fixed bug #346, when a string of word characters was passed to WordStart
  or `WordEnd` instead of just taking the default value. Originally posted
  as a question by Parag on StackOverflow, good catch!
  https://github.com/pyparsing/pyparsing/issues/346

- Fixed bug #350, in which `White` expressions could fail to match due to
  unintended whitespace-skipping. Reported by Fu Hanxi, thank you!
  https://github.com/pyparsing/pyparsing/issues/350

- Fixed bug #355, when a `QuotedString` is defined with characters in its
  quoteChar string containing regex-significant characters such as ., *,
  ?, [, ], etc.
  https://github.com/pyparsing/pyparsing/issues/355

- Fixed bug in `ParserElement.run_tests` where comments would be displayed
  using `with_line_numbers`.

- Added optional "min" and "max" arguments to `delimited_list`. PR
  submitted by Marius, thanks!

- Added new API change note in `whats_new_in_pyparsing_3_0_0`, regarding
  a bug fix in the `bool()` behavior of `ParseResults`.

  Prior to pyparsing 3.0.x, the `ParseResults` class implementation of
  `__bool__` would return `False` if the `ParseResults` item list was empty,
  even if it contained named results. In 3.0.0 and later, `ParseResults` will
  return `True` if either the item list is not empty *or* if the named
  results dict is not empty.

      # generate an empty ParseResults by parsing a blank string with
      # a ZeroOrMore
      result = Word(alphas)[...].parse_string("")
      print(result.as_list())
      print(result.as_dict())
      print(bool(result))

      # add a results name to the result
      result["name"] = "empty result"
      print(result.as_list())
      print(result.as_dict())
      print(bool(result))

  Prints:

      []
      {}
      False

      []
      {'name': 'empty result'}
      True

  In previous versions, the second call to `bool()` would return `False`.

- Minor enhancement to Word generation of internal regular expression, to
  emit consecutive characters in range, such as "ab", as "ab", not "a-b".

- Fixed character ranges for search terms using non-Western characters
  in booleansearchparser, PR submitted by tc-yu, nice work!

- Additional type annotations on public methods.

Version 3.0.6 -
---------------
- Added `suppress_warning()` method to individually suppress a warning on a
  specific ParserElement. Used to refactor `original_text_for` to preserve
  internal results names, which, while undocumented, had been adopted by
  some projects.

- Fix bug when `delimited_list` was called with a str literal instead of a
  parse expression.

Version 3.0.5 -
---------------
- Added return type annotations for `col`, `line`, and `lineno`.

- Fixed bug when `warn_ungrouped_named_tokens_in_collection` warning was raised
  when assigning a results name to an `original_text_for` expression.
  (Issue #110, would raise warning in packaging.)
  https://github.com/pyparsing/pyparsing/issues/110

- Fixed internal bug where `ParserElement.streamline()` would not return self if
  already streamlined.

- Changed `run_tests()` output to default to not showing line and column numbers.
  If line numbering is desired, call with `with_line_numbers=True`. Also fixed
  minor bug where separating line was not included after a test failure.

Version 3.0.4 -
---------------
- Fixed bug in which `Dict` classes did not correctly return tokens as nested
  `ParseResults`, reported by and fix identified by Bu Sun Kim, many thanks!!!

- Documented API-changing side-effect of converting `ParseResults` to use `__slots__`
  to pre-define instance attributes. This means that code written like this (which
  was allowed in pyparsing 2.4.7):

    result = Word(alphas).parseString("abc")
    result.xyz = 100

  now raises this Python exception:

    AttributeError: 'ParseResults' object has no attribute 'xyz'

  To add new attribute values to ParseResults object in 3.0.0 and later, you must
  assign them using indexed notation:

    result["xyz"] = 100

  You will still be able to access this new value as an attribute or as an
  indexed item.

- Fixed bug in railroad diagramming where the vertical limit would count all
  expressions in a group, not just those that would create visible railroad
  elements.


4. - [x] Additional research
    https://github.com/conda-forge/pyparsing-feedstock/issues

    `'version_info' object has no attribute '__version__' with python 3.6.0`
    https://github.com/conda-forge/pyparsing-feedstock/issues/36

    Currently there is only one open issue for `python` version `3.6.0`.
    However, since we no longer provide support for `python 3.6.0` we could conclude that there are no significant open issues mentioned that will affect the update of the package. 


5. - [x] Verify the `dev_url`
    https://github.com/pyparsing/pyparsing/
6. - [x] Verify the `doc_url`
    https://github.com/pyparsing/pyparsing/blob/master/docs/HowToUsePyparsing.rst
7. - [x] License is `spdx` compliant
    MIT
8. - [x] License family is present
    MIT
9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    setuptools
11. - [x] Verify if the package needs `wheel`
    wheel
12. - [x] `pip` in the test section
    pip
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Private variables are not mentioned on the recipe For example: (_private_variable)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `pyparsing` to version `3.0.9`
