### PR TITLE
v3.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
   requires:
     - pip
     - pytest
-    - matplotlib
+    - matplotlib-base
   commands:
     - pip check
     - pytest -vv . --ignore=tests/test_diagram.py -k "not (TestExamples or Test02_WithoutPackrat or Test04_WithPackrat or Test06_WithBoundedPackrat or Test08_WithUnboundedPackrat or Test09_WithLeftRecursionParsing or Test10_WithLeftRecursionParsingBoundedMemo)"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
     - matplotlib-base
   commands:
     - pip check
+    # skip tests that require 'railroad', unavailable
     - pytest -vv . --ignore=tests/test_diagram.py -k "not (TestExamples or Test02_WithoutPackrat or Test04_WithPackrat or Test06_WithBoundedPackrat or Test08_WithUnboundedPackrat or Test09_WithLeftRecursionParsing or Test10_WithLeftRecursionParsingBoundedMemo)"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.2" %}
+{% set version = "3.2.0" %}
 
 package:
   name: pyparsing
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyparsing/pyparsing-{{ version }}.tar.gz
-  sha256: a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad 
+  sha256: cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c 
     
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -30,6 +30,7 @@ test:
   requires:
     - pip
     - pytest
+    - matplotlib
   commands:
     - pip check
     - pytest -vv . --ignore=tests/test_diagram.py -k "not (TestExamples or Test02_WithoutPackrat or Test04_WithPackrat or Test06_WithBoundedPackrat or Test08_WithUnboundedPackrat or Test09_WithLeftRecursionParsing or Test10_WithLeftRecursionParsingBoundedMemo)"


### PR DESCRIPTION
pyparsing v3.2.0
**Destination channel:** defaults

### Links

- [PKG-5701](https://anaconda.atlassian.net/browse/PKG-5701) 
- [Upstream repository](https://github.com/pyparsing/pyparsing/tree/3.2.0)
- [Upstream changelog](https://github.com/pyparsing/pyparsing/releases/tag/3.2.0)

### Explanation of changes:

- Update version and SHA
- Restrict to python 3.9 and above
- Add missing test dependency: https://github.com/pyparsing/pyparsing/blob/3.2.0/tox.ini#L10


[PKG-5701]: https://anaconda.atlassian.net/browse/PKG-5701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ